### PR TITLE
Fix prettier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ executorType: docker
 jobs:
   build:
     environment:
-      - JEST_JUNIT_OUTPUT: "./test-results/junit.xml"
+      - JEST_JUNIT_OUTPUT: './test-results/junit.xml'
     working_directory: ~/app
     docker:
       - image: node:6.11.1
@@ -12,8 +12,8 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "yarn.lock" }}
-          - v1-dependencies-
+            - v1-dependencies-{{ checksum "yarn.lock" }}
+            - v1-dependencies-
       - run:
           name: Install Watchman
           command: |

--- a/.eslintrc
+++ b/.eslintrc
@@ -13,12 +13,10 @@
     "no-use-before-define": 0,
     "consistent-return": 0,
     "spaced-comment": 0,
-    "prefer-const": [ 2, { "destructuring": "all" }],
+    "prefer-const": [2, { "destructuring": "all" }],
     "guard-for-in": 0
   },
-  "plugins": [
-    "import"
-  ],
+  "plugins": ["import"],
   "env": {
     "es6": true,
     "node": true

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+__testfixtures__/

--- a/README.md
+++ b/README.md
@@ -20,11 +20,14 @@ comparison.
 ##### import-loaders-from-index
 
 Changes from
+
 ```js
 import MyLoaderA from './loader/MyLoaderA';
 import MyLoaderB from './loader/MyLoaderB';
 ```
+
 to
+
 ```js
 import { MyLoaderA, MyLoaderB } from './loader';
 ```

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "private": true,
   "scripts": {
     "prepare": "husky install",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "test": "jest --maxWorkers=50%",
     "test:ci": "jest --runInBand --forceExit",
     "lint": "eslint ."

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "jest-junit": "^2.1.0",
     "jscodeshift": "^0.3.32",
     "lint-staged": ">=10",
-    "prettier": "^1.5.3"
+    "prettier": "^2.5.1"
   },
   "workspaces": [
     "packages/*"

--- a/transforms/graphql-server/import-loaders-from-index.js
+++ b/transforms/graphql-server/import-loaders-from-index.js
@@ -2,7 +2,10 @@ import { lstatSync, readdirSync } from 'fs';
 import { basename, dirname, join } from 'path';
 
 const isDirectory = source => lstatSync(source).isDirectory();
-const getDirectories = source => readdirSync(source).map(name => join(source, name)).filter(isDirectory);
+const getDirectories = source =>
+  readdirSync(source)
+    .map(name => join(source, name))
+    .filter(isDirectory);
 
 const getLoaderFolderForPath = (filepath, levels = 0) => {
   const currentDirectoryPath = dirname(filepath);
@@ -39,19 +42,19 @@ export default (fileInfo, api) => {
   }
 
   // let's find the ./loader import
-  let loaderIndexImport = importDeclarations.filter(item => {
+  let loaderIndexImport = importDeclarations.filter((item) => {
     const { node } = item;
 
     return node.source.value.match(/\.\/loader$/);
   });
 
-  const loaderImports = importDeclarations.filter(item => {
+  const loaderImports = importDeclarations.filter((item) => {
     const { node } = item;
 
     return node.source.value.match(/\.\/loader\//);
   });
 
-  loaderImports.forEach(item => {
+  loaderImports.forEach((item) => {
     const importDefaultSpecifier = j(item).find(j.ImportDefaultSpecifier).nodes();
 
     if (!importDefaultSpecifier.length) {

--- a/transforms/graphql-server/move-static-loader-methods-to-direct-export.js
+++ b/transforms/graphql-server/move-static-loader-methods-to-direct-export.js
@@ -21,7 +21,7 @@ export default (fileInfo, api, options) => {
 
   // copied from
   // https://github.com/cpojer/js-codemod/blob/90a0081cabfcf371486d126d17fe8f0e8333ce7b/transforms/arrow-function.js#L7
-  const getBodyStatement = fn => {
+  const getBodyStatement = (fn) => {
     if (fn.body.type === 'BlockStatement' && fn.body.body.length === 1) {
       const inner = fn.body.body[0];
       const comments = (fn.body.comments || []).concat(inner.comments || []);
@@ -37,14 +37,14 @@ export default (fileInfo, api, options) => {
     return fn.body;
   };
 
-  const createArrowFunctionExpression = fn => {
+  const createArrowFunctionExpression = (fn) => {
     const arrowFunction = j.arrowFunctionExpression(fn.params, getBodyStatement(fn), false);
     arrowFunction.async = fn.async;
     arrowFunction.comments = fn.comments;
     return arrowFunction;
   };
 
-  const createNamedExportForItem = item => {
+  const createNamedExportForItem = (item) => {
     const { node } = item;
 
     if (node.static) {
@@ -77,7 +77,7 @@ export default (fileInfo, api, options) => {
   }
 
   classProperties.forEach(createNamedExportForItem);
-  classMethods.forEach(item => {
+  classMethods.forEach((item) => {
     const { node } = item;
 
     if (node.kind === 'constructor') {
@@ -98,7 +98,7 @@ export default (fileInfo, api, options) => {
   });
 
   //fix member expressions
-  program.find(j.MemberExpression).forEach(item => {
+  program.find(j.MemberExpression).forEach((item) => {
     const { node } = item;
 
     if (node.object.name === className && membersRemovedFromClass.indexOf(node.property.name) !== -1) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3117,9 +3117,10 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.5.3:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.5.3.tgz#59dadc683345ec6b88f88b94ed4ae7e1da394bfe"
+prettier@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
+  integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
 
 pretty-format@^20.0.3:
   version "20.0.3"


### PR DESCRIPTION
This PR makes the following changes:
- Update prettier version (`1.5.3` to `2.5.1`)
- Add ignore file (`.prettierignore`)
- Add basic format scripts (`format` and `format:check`)
- Format files using prettier