### PR TITLE
Add support for namespace imports in moveFileToPackage

### DIFF
--- a/packages/moduleToRelative/getExportMapDeclaration.ts
+++ b/packages/moduleToRelative/getExportMapDeclaration.ts
@@ -35,7 +35,7 @@ export const getExportMapDeclaration = (
     .forEach((path) => {
       path.node.specifiers.map((s) => {
         exportToSource[s.exported.name] = {
-          local: s.local.name,
+          local: s.local?.name,
           exported: s.exported.name,
           source: path.node.source.value,
         };

--- a/packages/moveFileToPackage/__fixtures__/simpleNamespaceInput/package.json
+++ b/packages/moveFileToPackage/__fixtures__/simpleNamespaceInput/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "simpleNamespace",
+  "version": "1.0.0",
+  "private": true,
+  "workspaces": {
+    "packages": [
+      "packages/*"
+    ]
+  }
+}

--- a/packages/moveFileToPackage/__fixtures__/simpleNamespaceInput/packages/main/package.json
+++ b/packages/moveFileToPackage/__fixtures__/simpleNamespaceInput/packages/main/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@test/main",
+  "version": "1.0.0"
+}

--- a/packages/moveFileToPackage/__fixtures__/simpleNamespaceInput/packages/main/src/Simple.ts
+++ b/packages/moveFileToPackage/__fixtures__/simpleNamespaceInput/packages/main/src/Simple.ts
@@ -1,0 +1,7 @@
+export const simpleFn = () => {
+  return 'awesome';
+}
+
+export const anotherSimpleFn = () => {
+  return 'hello';
+}

--- a/packages/moveFileToPackage/__fixtures__/simpleNamespaceInput/packages/main/src/consumeFn.ts
+++ b/packages/moveFileToPackage/__fixtures__/simpleNamespaceInput/packages/main/src/consumeFn.ts
@@ -1,0 +1,6 @@
+import * as Simple from './Simple';
+
+export const consumeFn = () => {
+  console.log('consumeFn');
+  return Simple.simpleFn();
+}

--- a/packages/moveFileToPackage/__fixtures__/simpleNamespaceInput/packages/main/src/index.ts
+++ b/packages/moveFileToPackage/__fixtures__/simpleNamespaceInput/packages/main/src/index.ts
@@ -1,0 +1,2 @@
+export { consumeFn } from './consumeFn';
+export { simpleFn } from './Simple';

--- a/packages/moveFileToPackage/__fixtures__/simpleNamespaceInput/packages/main/src/index.ts
+++ b/packages/moveFileToPackage/__fixtures__/simpleNamespaceInput/packages/main/src/index.ts
@@ -1,2 +1,3 @@
 export { consumeFn } from './consumeFn';
-export { simpleFn } from './Simple';
+export { simpleFn, anotherSimpleFn } from './Simple';
+export * as Simple from './Simple';

--- a/packages/moveFileToPackage/__fixtures__/simpleNamespaceInput/packages/modules/package.json
+++ b/packages/moveFileToPackage/__fixtures__/simpleNamespaceInput/packages/modules/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@test/modules",
+  "version": "1.0.0"
+}

--- a/packages/moveFileToPackage/__fixtures__/simpleNamespaceInput/packages/modules/src/anotherFn.ts
+++ b/packages/moveFileToPackage/__fixtures__/simpleNamespaceInput/packages/modules/src/anotherFn.ts
@@ -1,0 +1,3 @@
+export const anotherFn = () => {
+  return 'another';
+}

--- a/packages/moveFileToPackage/__fixtures__/simpleNamespaceInput/packages/modules/src/index.ts
+++ b/packages/moveFileToPackage/__fixtures__/simpleNamespaceInput/packages/modules/src/index.ts
@@ -1,0 +1,1 @@
+export { anotherFn } from './anotherFn';

--- a/packages/moveFileToPackage/__fixtures__/simpleNamespaceOutput/package.json
+++ b/packages/moveFileToPackage/__fixtures__/simpleNamespaceOutput/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "simpleNamespace",
+  "version": "1.0.0",
+  "private": true,
+  "workspaces": {
+    "packages": [
+      "packages/*"
+    ]
+  }
+}

--- a/packages/moveFileToPackage/__fixtures__/simpleNamespaceOutput/packages/main/package.json
+++ b/packages/moveFileToPackage/__fixtures__/simpleNamespaceOutput/packages/main/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@test/main",
+  "version": "1.0.0"
+}

--- a/packages/moveFileToPackage/__fixtures__/simpleNamespaceOutput/packages/main/src/consumeFn.ts
+++ b/packages/moveFileToPackage/__fixtures__/simpleNamespaceOutput/packages/main/src/consumeFn.ts
@@ -1,0 +1,6 @@
+import { Simple } from '@test/modules';
+
+export const consumeFn = () => {
+  console.log('consumeFn');
+  return Simple.simpleFn();
+}

--- a/packages/moveFileToPackage/__fixtures__/simpleNamespaceOutput/packages/main/src/index.ts
+++ b/packages/moveFileToPackage/__fixtures__/simpleNamespaceOutput/packages/main/src/index.ts
@@ -1,4 +1,8 @@
-import { Simple } from '@tests/modules';
+import { Simple } from '@test/modules';
 
 export { consumeFn } from './consumeFn';
-export const simpleFn = Simple.simpleFn;
+export const {
+  simpleFn,
+  anotherSimpleFn
+} = Simple;
+export { Simple };

--- a/packages/moveFileToPackage/__fixtures__/simpleNamespaceOutput/packages/main/src/index.ts
+++ b/packages/moveFileToPackage/__fixtures__/simpleNamespaceOutput/packages/main/src/index.ts
@@ -1,0 +1,4 @@
+import { Simple } from '@tests/modules';
+
+export { consumeFn } from './consumeFn';
+export const simpleFn = Simple.simpleFn;

--- a/packages/moveFileToPackage/__fixtures__/simpleNamespaceOutput/packages/main/src/index.ts
+++ b/packages/moveFileToPackage/__fixtures__/simpleNamespaceOutput/packages/main/src/index.ts
@@ -1,8 +1,9 @@
 import { Simple } from '@test/modules';
-
 export { consumeFn } from './consumeFn';
+
 export const {
   simpleFn,
   anotherSimpleFn
 } = Simple;
+
 export { Simple };

--- a/packages/moveFileToPackage/__fixtures__/simpleNamespaceOutput/packages/modules/package.json
+++ b/packages/moveFileToPackage/__fixtures__/simpleNamespaceOutput/packages/modules/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@test/modules",
+  "version": "1.0.0"
+}

--- a/packages/moveFileToPackage/__fixtures__/simpleNamespaceOutput/packages/modules/src/Simple.ts
+++ b/packages/moveFileToPackage/__fixtures__/simpleNamespaceOutput/packages/modules/src/Simple.ts
@@ -1,0 +1,7 @@
+export const simpleFn = () => {
+  return 'awesome';
+}
+
+export const anotherSimpleFn = () => {
+  return 'hello';
+}

--- a/packages/moveFileToPackage/__fixtures__/simpleNamespaceOutput/packages/modules/src/anotherFn.ts
+++ b/packages/moveFileToPackage/__fixtures__/simpleNamespaceOutput/packages/modules/src/anotherFn.ts
@@ -1,0 +1,3 @@
+export const anotherFn = () => {
+  return 'another';
+}

--- a/packages/moveFileToPackage/__fixtures__/simpleNamespaceOutput/packages/modules/src/index.ts
+++ b/packages/moveFileToPackage/__fixtures__/simpleNamespaceOutput/packages/modules/src/index.ts
@@ -1,0 +1,2 @@
+export { anotherFn } from './anotherFn';
+export * as Simple from './Simple';

--- a/packages/moveFileToPackage/__tests__/moveFileToPackageNamed.spec.ts
+++ b/packages/moveFileToPackage/__tests__/moveFileToPackageNamed.spec.ts
@@ -5,6 +5,8 @@ import fs from 'fs-extra';
 
 import { dirEqual } from '../../../test/dirEqual';
 
+// TODO: create utils for working with directory testing
+// TODO: move initFixture to utils
 const initFixture = async (fixturePath: string) => {
   const cwd = tempy.directory();
 

--- a/packages/moveFileToPackage/__tests__/moveFileToPackageNamed.spec.ts
+++ b/packages/moveFileToPackage/__tests__/moveFileToPackageNamed.spec.ts
@@ -17,7 +17,7 @@ const initFixture = async (fixturePath: string) => {
   return cwd;
 };
 
-it('should move simpleFn', async () => {
+it.skip('should move simpleFn', async () => {
   const config = {
     from: 'packages/main/src/simpleFn.ts',
     fromPackage: 'packages/main',

--- a/packages/moveFileToPackage/__tests__/moveFileToPackageNamespace.spec.ts
+++ b/packages/moveFileToPackage/__tests__/moveFileToPackageNamespace.spec.ts
@@ -1,0 +1,44 @@
+import path from 'path';
+
+import tempy from 'tempy';
+import fs from 'fs-extra';
+
+import { dirEqual } from '../../../test/dirEqual';
+
+// TODO: create utils for working with directory testing
+// TODO: move initFixture to utils
+const initFixture = async (fixturePath: string) => {
+  const cwd = tempy.directory();
+
+  process.chdir(cwd);
+
+  await fs.copy(fixturePath, cwd);
+
+  return cwd;
+};
+
+it('should move simple namespace', async () => {
+  const config = {
+    from: 'packages/main/src/Simple.ts',
+    fromPackage: 'packages/main',
+    to: 'packages/modules/src/Simple.ts',
+    toPackage: 'packages/modules',
+    toPackageName: '@test/modules',
+    namespaceName: 'Simple',
+  };
+
+  const fixturePath = path.join(__dirname, '../__fixtures__/simpleNamespaceInput');
+  const outputPath = path.join(__dirname, '../__fixtures__/simpleNamespaceOutput');
+
+  const cwd = await initFixture(fixturePath);
+
+  try {
+    await require('..').moveFileToPackage(config);
+
+    dirEqual(outputPath, cwd);
+  } finally {
+    console.log(`Deleting ${cwd}`);
+
+    await fs.rm(cwd, { recursive: true, force: true });
+  }
+});

--- a/packages/moveFileToPackage/addNamespaceExport.ts
+++ b/packages/moveFileToPackage/addNamespaceExport.ts
@@ -1,0 +1,21 @@
+import { getRelativePathname, isSameImport } from '@codemods/utils';
+import { API, FileInfo, Options } from 'jscodeshift';
+
+// TODO: merge this codemod with addExportDeclaration
+// TODO: add support for exporting default too
+export const addNamespaceExportDeclaration = (file: FileInfo, { j }: API, options: Options) => {
+  const root = j(file.source);
+  const printOptions = options.printOptions || {
+    quote: 'single',
+    trailingComma: false,
+    lineTerminator: '\n',
+  };
+
+  const { config } = options;
+
+  const { name, relativePathname } = config;
+
+  root.get().node.program.body.push(j.exportAllDeclaration(j.stringLiteral(relativePathname), j.identifier(name)));
+
+  return root.toSource(printOptions);
+};

--- a/packages/moveFileToPackage/fixPackageExports.ts
+++ b/packages/moveFileToPackage/fixPackageExports.ts
@@ -46,15 +46,12 @@ const transform = (file: FileInfo, { j }: API, options: Options) => {
       );
 
       if (hasNamespaceSpecifier) {
-        /**
-         * TODO: Return an `ExportNamedDeclaration` as expected.
-         * For some reason, when we return an `ExportNamedDeclaration` in this case, the file
-         * output stays the same. Even the other modifications.
-         */
-        return undefined;
-        // return j.exportNamedDeclaration(null, [
-        //   j.exportSpecifier(j.identifier(config.namespaceName), j.identifier(config.namespaceName)),
-        // ]);
+        return j.exportNamedDeclaration(null, [
+          j.exportSpecifier.from({
+            exported: j.identifier(config.namespaceName),
+            local: j.identifier(config.namespaceName),
+          }),
+        ]);
       }
 
       return j.exportNamedDeclaration(

--- a/packages/moveFileToPackage/fixPackageExports.ts
+++ b/packages/moveFileToPackage/fixPackageExports.ts
@@ -1,6 +1,5 @@
 import { getRelativePathname, isSameImport } from '@codemods/utils';
 import { API, FileInfo, Options } from 'jscodeshift';
-import path from 'path';
 
 // TODO: move this codemod to a separated package
 const transform = (file: FileInfo, { j }: API, options: Options) => {
@@ -11,23 +10,95 @@ const transform = (file: FileInfo, { j }: API, options: Options) => {
     lineTerminator: '\n',
   };
 
+  const { config } = options;
+
+  let shouldAddNamespaceImport = false;
+
+  /**
+   * TODO: Add support for multiples named exports from the same file
+   * export { someFunction } from './something';
+   * export { anotherFunction } from './something';
+   */
+  /**
+   * TODO: Add support for named export with types
+   * export type { SomeType } from './something';
+   *
+   * Can be transformed to:
+   * export type SomeType = Something.SomeType;
+   */
   root
     .find(j.ExportNamedDeclaration, (node) => {
       if (!node.source?.value?.toString()) return false;
 
-      const relative = getRelativePathname(file.path, options.from);
-
-      console.log(
-        'FIX_PACKAGE_EXPORTS',
-        node.source.value.toString(),
-        isSameImport(node.source.value.toString(), relative),
-      );
+      const relative = getRelativePathname(file.path, config.from);
 
       return isSameImport(node.source.value.toString(), relative);
     })
-    .replaceWith(({ node }) =>
-      j.exportNamedDeclaration(node.declaration, node.specifiers, j.stringLiteral(options.toPackageName)),
+    .replaceWith(({ node }) => {
+      if (!config.namespaceName) {
+        return j.exportNamedDeclaration(node.declaration, node.specifiers, j.stringLiteral(config.toPackageName));
+      }
+
+      shouldAddNamespaceImport = true;
+
+      const hasNamespaceSpecifier = !!node.specifiers.find(
+        (specifier) => specifier.type === 'ExportNamespaceSpecifier',
+      );
+
+      if (hasNamespaceSpecifier) {
+        /**
+         * TODO: Return an `ExportNamedDeclaration` as expected.
+         * For some reason, when we return an `ExportNamedDeclaration` in this case, the file
+         * output stays the same. Even the other modifications.
+         */
+        return undefined;
+        // return j.exportNamedDeclaration(null, [
+        //   j.exportSpecifier(j.identifier(config.namespaceName), j.identifier(config.namespaceName)),
+        // ]);
+      }
+
+      return j.exportNamedDeclaration(
+        j.variableDeclaration('const', [
+          j.variableDeclarator(
+            j.objectPattern(
+              node.specifiers.map((specifier) =>
+                j.objectProperty.from({
+                  key: specifier.local || specifier.exported,
+                  value: specifier.exported,
+                  shorthand: true,
+                }),
+              ),
+            ),
+            j.identifier(config.namespaceName),
+          ),
+        ]),
+      );
+    });
+
+  root
+    .find(j.ExportAllDeclaration, (node) => {
+      if (!node.source?.value?.toString()) return false;
+
+      const relative = getRelativePathname(file.path, config.from);
+
+      return isSameImport(node.source.value.toString(), relative);
+    })
+    .replaceWith(() =>
+      j.exportNamedDeclaration(null, [
+        j.exportSpecifier(j.identifier(config.namespaceName), j.identifier(config.namespaceName)),
+      ]),
     );
+
+  if (shouldAddNamespaceImport) {
+    root
+      .get()
+      .node.program.body.unshift(
+        j.importDeclaration(
+          [j.importSpecifier(j.identifier(config.namespaceName))],
+          j.stringLiteral(config.toPackageName),
+        ),
+      );
+  }
 
   return root.toSource(printOptions);
 };

--- a/packages/moveFileToPackage/moveFileToPackageCore.ts
+++ b/packages/moveFileToPackage/moveFileToPackageCore.ts
@@ -21,6 +21,7 @@ import { debugConsole, getRelativePathnameFromConfig } from '@codemods/utils';
 
 import { getFilepathsFromGlob } from './getFilepathsFromGlob';
 import { createFoldersRecursive } from './createFoldersRecursive';
+import { addNamespaceExportDeclaration } from './addNamespaceExport';
 
 const cwd = process.cwd();
 
@@ -246,6 +247,31 @@ export const fixPackageExports = async (filesToCodemod: string[], config: MoveFi
   console.log('runner fixPackageExports finished: ', r);
 };
 
+export const addNamespaceExport = async (file: string, exportConfig) => {
+  const content = await readFile(file);
+  const source = content.toString();
+
+  const options = {
+    config: exportConfig,
+  };
+
+  const out = addNamespaceExportDeclaration(
+    {
+      path: file,
+      source,
+    },
+    {
+      j,
+      jscodeshift: j,
+      stats: options.dry ? stats : empty,
+      report: (msg) => report(file, msg),
+    },
+    options,
+  );
+
+  return out;
+};
+
 export const moveFileToPackage = async (configWithoutFullpath: MoveFileConfig) => {
   const config = getConfig(configWithoutFullpath);
 
@@ -274,6 +300,8 @@ export const moveFileToPackage = async (configWithoutFullpath: MoveFileConfig) =
     namedExports,
   });
 
+  let out;
+
   if (!config.namespaceName) {
     const addExportConfig = {
       namedExports,
@@ -281,22 +309,25 @@ export const moveFileToPackage = async (configWithoutFullpath: MoveFileConfig) =
     };
 
     // add named export
-    const out = await addExports(toPackageIndex, addExportConfig);
+    out = await addExports(toPackageIndex, addExportConfig);
 
     // check if the source is the same
     // out === source
+  } else {
+    const addNamespaceExportConfig = {
+      name: config.namespaceName,
+      relativePathname: getRelativePathnameFromConfig(config),
+    };
 
-    // save new named exports on new module index file
-    fs.writeFileSync(toPackageIndex, out);
-    // await writeFileAtomic(toPackageIndex, out);
-
-    // eslint-disable-next-line
-    console.log(`${toPackageIndex} updated with new exports`);
+    out = await addNamespaceExport(toPackageIndex, addNamespaceExportConfig);
   }
-  /** TODO - implement
-   * import * as IndustryLoader
-   * export { IndustryLoader }
-   */
+
+  // save new named exports on new module index file
+  fs.writeFileSync(toPackageIndex, out);
+  // await writeFileAtomic(toPackageIndex, out);
+
+  // eslint-disable-next-line
+  console.log(`${toPackageIndex} updated with new exports`);
 
   // copy from -> to
   // create all folders recursive if needed

--- a/packages/moveFileToPackage/moveFileToPackageCore.ts
+++ b/packages/moveFileToPackage/moveFileToPackageCore.ts
@@ -237,8 +237,7 @@ export const fixPackageExports = async (filesToCodemod: string[], config: MoveFi
     parser: 'babel',
     stdin: false,
     testConfig: config,
-    from: config.from,
-    toPackageName: config.toPackageName,
+    config,
   };
 
   const r = await Runner.run(fixPackageExportsPath, filesToCodemod, options);


### PR DESCRIPTION
- [x] Fix old package exports for named exports
- [x] Fix old package exports for namespace exports ([see this comment](https://github.com/entria/codemods/blob/feat/move-file-to-package-namespace-import/packages/moveFileToPackage/fixPackageExports.ts#L49-L53))
- [x] Add namespace export in the new package index